### PR TITLE
Fixes #4 Fixes #7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 1.1.1
+
+- Fix referencing error on `console.log` and `console.error`
+  These were previously overwritten by `console.info` and console.warn`
+- Fix the match criteria in the console.trace test to accommodate
+  phantomJS 2.2.1 trace format
+
 ## 1.1.0
 
 Streams 3: Update `through2` to `2.0`

--- a/lib/brout.js
+++ b/lib/brout.js
@@ -64,12 +64,13 @@ var originalLog   = console.log;
 var originalInfo  = console.info;
 var originalWarn  = console.warn;
 var originalError = console.error;
+var originalTrace = console.trace;
 
 redirectLog('log', 'stdout');
+redirectLog('info', 'stdout');
 redirectLog('warn', 'stderr');
+redirectLog('error', 'stderr');
 
-console.info  = console.log;
-console.error = console.warn;
 
 console.trace = function () {
   try {
@@ -87,6 +88,7 @@ console.log.original   = originalLog;
 console.info.original  = originalInfo;
 console.warn.original  = originalWarn;
 console.error.original = originalError;
+console.trace.original = originalTrace;
 
 process.exit = function (code) {
   if (emitter.listeners('exit').length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brout",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "stdout and stderr for browsers",
   "keywords": [
     "stdout",
@@ -22,7 +22,7 @@
   "scripts": {
     "lint": "jslint --edition=latest --color \"**/*.js\"",
     "pretest": "npm run lint",
-    "test": "browserify -p mocaccino ./test/*.js | phantomic"
+    "test": "browserify -p mocaccino test/brout-test.js | phantomic"
   },
   "repository": {
     "type": "git",

--- a/test/brout-test.js
+++ b/test/brout-test.js
@@ -5,7 +5,11 @@
  *
  * @license MIT
  */
-/*globals describe, it, beforeEach, afterEach*/
+/*jslint
+ regexp: true
+ debug: true
+ */
+/*globals describe, it, beforeEach, afterEach, debugger*/
 'use strict';
 
 var brout  = require('../lib/brout');
@@ -225,12 +229,15 @@ describe('brout', function () {
       console.trace();
 
       assert(fake.called);
-      var lines = fake.args[0].split('\n');
-      assert(lines.length > 0);
-      lines.slice(0, lines.length - 1).forEach(function (line) {
-        assert.equal(line.indexOf("    at "), 0, line);
+      var l, lines = fake.args[0].split('\n');
+      assert(l = lines.length > 0);
+      lines.slice(0, l = l - 1).forEach(function (line, i) {
+        if (i !== l) {
+          assert.ok(!!line.match(/(?=^\s+at\s+)|(^.*@http:\/\/.+)/), line);
+        } else {
+          assert.equal(line, '');
+        }
       });
-      assert.equal(lines[lines.length - 1], '');
     } finally {
       process.stdout.write = originalWrite;
     }


### PR DESCRIPTION
Fixes #4: a referencing bug issue
- fallback for stdout and stderr as console.info and console.warn respectively
- this patch hooks  stdout and stderr to console.log and console.err respectively
  
  Fixes #7: failing logs traces test
- phantomJS 2.0 has a new stack frame format that is now accommodated
  
  Also replaced the glob in the test script with a literal path because the glob was not resolved in Windows
